### PR TITLE
Always specify a sane timeout for http.Client

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -277,7 +277,7 @@ if c.Door != nil {
 }
 ```
 
-## Always set a sane value for timeouts when using http.Client
+### Always set a sane value for timeouts when using http.Client
 
 When initializing a HTTP Client generally people use
 

--- a/go/README.md
+++ b/go/README.md
@@ -277,6 +277,39 @@ if c.Door != nil {
 }
 ```
 
+## Always set a sane value for timeouts when using http.Client
+
+When initializing a HTTP Client generally people use
+
+```go
+
+client := &http.Client{}
+```
+
+However, this allows someone to hijack your goroutines. Look at this simple example:
+
+```go
+  svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    time.Sleep(time.Hour)
+  }))
+```
+
+When you use
+
+```go
+http.Get(svr.URL)
+```
+
+Your client will hang for an hour and then terminate. In order to remedy this _always specify a sane timeout_:
+
+```go
+client := &http.Client{
+  Timeout: time.second * 10,
+}
+```
+
+Reference: [Don't use Go's default HTTP client (in production)](https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779)
+
 
 ## Recommended libaries
 


### PR DESCRIPTION
A simple PR to give new engineers a warning about goroutine hijacking via `http.Client`.